### PR TITLE
add script for cctp

### DIFF
--- a/bin/deploy_cctp_adapter.sh
+++ b/bin/deploy_cctp_adapter.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+source ./.env
+
+forge script script/adapters/CCTPAdapter.s.sol --rpc-url arbitrum_sepolia --broadcast --verify -vvvv --via-ir --ffi --private-key $PRIVATE_KEY

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "deploy:spoke": "./bin/deploy_spoke_chain.sh",
     "deploy:eth-adpter": "./bin/deploy_eth_adapter.sh",
     "deploy:axelar-adapter": "./bin/deploy_axelar_adapter.sh",
+    "deploy:cctp-adapter": "./bin/deploy_cctp_adapter.sh",
     "format": "forge fmt",
     "coverage": "forge coverage",
     "deposit": "./bin/deposit.sh",

--- a/script/adapters/CCTPAdapter.s.sol
+++ b/script/adapters/CCTPAdapter.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.23;
+
+import { BaseScript } from "../Base.s.sol";
+import { CCTPAdapter } from "../../src/adapters/CCTPAdapter.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract CCTPAdapterScript is BaseScript {
+    CCTPAdapter cctpAdapter;
+    address usdc = 0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d;
+    address tokenMessanger = 0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5;
+    address receipient = 0xc92FE6Db0a49C339E1D56eB23ECF6a7251aac67C;
+    uint256 amount = 100_000;
+    uint256 dstChainId = 84_532;
+
+    function run() public broadcast {
+        cctpAdapter = new CCTPAdapter(broadcaster, tokenMessanger, usdc);
+
+        IERC20(usdc).approve(address(cctpAdapter), amount);
+
+        cctpAdapter.execCrossChainTransferAsset(broadcaster, dstChainId, receipient, usdc, amount, 0, bytes(""));
+    }
+}

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -66,12 +66,12 @@ contract CCTPAdapter is IL2BridgeAdapter, Ownable {
         token = IERC20(_token);
 
         uint256[] memory chainIds = new uint256[](6);
-        chainIds[0] = 11155111; // Sepolia
-        chainIds[1] = 43113; // Avalanche Fuji
-        chainIds[2] = 11155420; // OP Sepolia 
-        chainIds[3] = 421614; // Arbitrum Sepolia 
-        chainIds[4] = 84532; // Base Sepolia
-        chainIds[5] = 80002; // Polygon Amoy
+        chainIds[0] = 11_155_111; // Sepolia
+        chainIds[1] = 43_113; // Avalanche Fuji
+        chainIds[2] = 11_155_420; // OP Sepolia
+        chainIds[3] = 421_614; // Arbitrum Sepolia
+        chainIds[4] = 84_532; // Base Sepolia
+        chainIds[5] = 80_002; // Polygon Amoy
         uint32[] memory domainsArray = new uint32[](6);
         domainsArray[0] = 0;
         domainsArray[1] = 1;
@@ -80,6 +80,8 @@ contract CCTPAdapter is IL2BridgeAdapter, Ownable {
         domainsArray[4] = 6;
         domainsArray[5] = 7;
         _setChainIdsToDomains(chainIds, domainsArray);
+
+        mintRecipients[6] = 0xc92FE6Db0a49C339E1D56eB23ECF6a7251aac67C;
     }
 
     /* ----------------------------- Functions -------------------------------- */
@@ -108,8 +110,7 @@ contract CCTPAdapter is IL2BridgeAdapter, Ownable {
     )
         external
         payable
-    {
-    }
+    { }
 
     function execCrossChainTransferAsset(
         address sender,
@@ -127,6 +128,9 @@ contract CCTPAdapter is IL2BridgeAdapter, Ownable {
             revert NotSupportedToken();
         }
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        IERC20(token).approve(address(tokenMessenger), amount);
+
         _cctpSend(sender, dstChainId, amount, recipient);
     }
 


### PR DESCRIPTION
## What I implemented
`CCTPAdapter.sol`
- Token approval is implemented before sending USDC to `TokenMessager`
- Dummy address set for `mintRecipients` in constructor (Essentially sets the address of any `CCTPReceiver`)

in `CCTPAdapter.s.sol` Implemented script to
- deploy `CCTPAdapter.sol`
- approve USDC to `CCTPAdapter.sol`
- call `execCrossChainTransferAsset()` (fee and param are not needed, so they are 0 and blank)

`deploy_cctp_adapter.sh`
- implemented a shell script to run forge script
- Requires an optional private key, Arbitrum Sepolia's RPC endpoint, and Explorer's API key if verifying the contract
- Add yarn command

## How to run
Shell script authorization;
`chmod +x ./bin/deploy_cctp_adapter.sh`

Deploy `CCTPAdapter.sol` and send txn;
`yarn deploy:cctp-adapter`